### PR TITLE
fix: Bump tfplugindocs to v0.25.0 for renewed HashiCorp GPG key

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Validate Docs
         run: |-
-          go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.24.0 validate
-          go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.24.0 generate \
+          go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.25.0 validate
+          go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.25.0 generate \
             -rendered-provider-name "Utility Functions" >/dev/null
           git diff --exit-code docs/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BUILD_DIR             := .local/builds
 PLATFORMS             := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 GOLANGCI_LINT_VERSION := v2.11.4
 GOVULNCHECK_VERSION   := v1.1.4
-TFPLUGINDOCS_VERSION  := v0.24.0
+TFPLUGINDOCS_VERSION  := v0.25.0
 
 .PHONY: all build clean docs format install lint test testacc update
 


### PR DESCRIPTION
- Bumps `TFPLUGINDOCS_VERSION` in the Makefile and `.github/workflows/lint.yml` from `v0.24.0` to `v0.25.0`
- tfplugindocs v0.24.0 pins hc-install v0.9.2, which embeds the HashiCorp release signing key `72D7468F` that expired 2026-04-18 and caused the Validate Docs job to fail with `openpgp: key expired`
- tfplugindocs v0.25.0 pins hc-install v0.9.4, which ships the renewed key valid until 2030-03-01
- Refs: HCSEC-2026-03, hashicorp/hc-install#370