### PR TITLE
fix: Resolve govulncheck vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/craigsloggett/terraform-provider-utility-functions
 
-go 1.25.10
+go 1.25.11
 
 require github.com/hashicorp/terraform-plugin-framework v1.19.0
 


### PR DESCRIPTION
- Bump the `go` directive to 1.25.11 to clear two Go standard-library vulnerabilities that govulncheck flags against the `go 1.25.10` toolchain
- GO-2026-5037: quadratic candidate-hostname parsing in `crypto/x509`
- GO-2026-5039: unescaped arbitrary inputs in `net/textproto` errors
- 1.25.11 is the lowest version fixing both, and the final 1.25.x patch; stdlib-only, so no `require`/`go.sum` changes are needed