### PR TITLE
chore: Align scaffolding with terraform-provider-template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,18 +6,18 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore
+      prefix: chore(ci)
 
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore
+      prefix: chore(deps)
 
   - package-ecosystem: terraform
     directory: /
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore
+      prefix: chore(deps)

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   title:
     name: Semantic Title
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # 6.1.1
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:
           requireScope: false
         env:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,7 @@
 extends: relaxed
 
+ignore-from-file: .gitignore
+
 rules:
   comments:
     level: error


### PR DESCRIPTION
- Moves pre-release to `ubuntu-24.04`
- Dependabot prefixes → `chore(ci)`/`chore(deps)` (the `terraform` ecosystem entry stays, now template canon)
- Adds `ignore-from-file: .gitignore` to the yamllint config
- Keeps the customized `.releaserc.yml`